### PR TITLE
chore: clean up Dependabot config by removing empty assignees and reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    # Assign pull requests to no one (optional)
-    assignees:
-      - ""
     # Customize labels on pull requests
     labels:
       - "dependencies"
@@ -33,9 +30,6 @@ updates:
           - "dev-*"
           - "*-dev"
           - "test-*"
-    # Add reviewers (optional)
-    reviewers:
-      - ""
       
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
This PR addresses issue #91 by cleaning up the Dependabot configuration.

**Changes:**
- Removed empty string entries from assignees and reviewers fields in the cargo update configuration
- This fixes invalid configuration that could cause warnings or be ignored
- All other configuration options remain intact

**Before:**
```yaml
assignees:
  - ""
reviewers:
  - ""
```

**After:**
- These fields are completely removed since they contained invalid empty strings

This resolves the configuration issue mentioned in the issue and ensures Dependabot runs without config warnings.

Fixes #91