### PR TITLE
fix(scanner): collapse nested if per clippy

### DIFF
--- a/src/database/updater.rs
+++ b/src/database/updater.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
 use log::{info, warn};
-use reqwest::blocking::Client;
 use reqwest::Url;
+use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -125,7 +125,11 @@ impl DatabaseUpdater {
     /// Update the database to the latest version
     pub fn update_database(&mut self, force: bool) -> Result<UpdateSummary> {
         // Check if update is needed unless forced
-        let update_needed = if !force { self.check_for_updates()? } else { true };
+        let update_needed = if !force {
+            self.check_for_updates()?
+        } else {
+            true
+        };
 
         if !update_needed && !force {
             return Err(anyhow!(

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -120,16 +120,16 @@ impl Scanner {
         println!("Quick scanning: {}", path.display());
 
         // Special detection for EICAR test file
-        if let Ok(content) = fs::read_to_string(path) {
-            if content.contains("EICAR-STANDARD-ANTIVIRUS-TEST-FILE") {
-                return Ok(ScanResult {
-                    malicious: true,
-                    threat_name: Some("EICAR Test File".into()),
-                    file_hash: Some(
-                        "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f".into(),
-                    ),
-                });
-            }
+        if let Ok(content) = fs::read_to_string(path)
+            && content.contains("EICAR-STANDARD-ANTIVIRUS-TEST-FILE")
+        {
+            return Ok(ScanResult {
+                malicious: true,
+                threat_name: Some("EICAR Test File".into()),
+                file_hash: Some(
+                    "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f".into(),
+                ),
+            });
         }
 
         // Default case for regular files

--- a/tests/onboarding_hash_cli.rs
+++ b/tests/onboarding_hash_cli.rs
@@ -21,14 +21,11 @@ fn sha256_hex(bytes: &[u8]) -> String {
 #[ignore = "onboarding assignment: implement `hash` subcommand"]
 fn hash_help_mentions_required_flags() {
     let mut cmd = Command::cargo_bin("malware_minimizer").unwrap();
-    cmd.args(["hash", "--help"])
-        .assert()
-        .success()
-        .stdout(
-            predicate::str::contains("Usage:")
-                .or(predicate::str::contains("USAGE:"))
-                .and(predicate::str::contains("--path")),
-        );
+    cmd.args(["hash", "--help"]).assert().success().stdout(
+        predicate::str::contains("Usage:")
+            .or(predicate::str::contains("USAGE:"))
+            .and(predicate::str::contains("--path")),
+    );
 }
 
 #[test]
@@ -52,16 +49,12 @@ fn hash_sha256_file_human_output_contains_hash_and_filename() {
     let expected_hash = sha256_hex(content);
 
     let mut cmd = Command::cargo_bin("malware_minimizer").unwrap();
-    cmd.args([
-        "hash",
-        "--path",
-        file_path.to_string_lossy().as_ref(),
-    ])
-    .assert()
-    .success()
-    .stdout(predicate::str::contains("sha256"))
-    .stdout(predicate::str::contains(expected_hash))
-    .stdout(predicate::str::contains("hello.txt"));
+    cmd.args(["hash", "--path", file_path.to_string_lossy().as_ref()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sha256"))
+        .stdout(predicate::str::contains(expected_hash))
+        .stdout(predicate::str::contains("hello.txt"));
 }
 
 #[test]
@@ -96,7 +89,12 @@ fn hash_sha256_file_json_is_valid_ndjson() {
 
     assert_eq!(v["algo"], "sha256");
     assert_eq!(v["hash"], expected_hash);
-    assert!(v["path"].as_str().unwrap_or_default().contains("one.json.txt"));
+    assert!(
+        v["path"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("one.json.txt")
+    );
     assert_eq!(v["size"].as_u64(), Some(content.len() as u64));
 }
 
@@ -130,4 +128,3 @@ fn hash_nonexistent_path_fails() {
         .assert()
         .failure();
 }
-


### PR DESCRIPTION
## Description
Collapsed nested `if let` + `if` into a single condition using let-chains, as suggested by clippy::collapsible_if.

Also ran `cargo fmt` on unformatted files.

## Related Issue
Fixes #95 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Test improvement
- [ ] Other

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the project's code style
- [ ] I have updated the documentation
- [ ] I have added tests to cover my changes
- [x] All new and existing tests pass
- [x] I have checked for and resolved any merge conflicts