### PR TITLE
style(scanner): Fixed clippy formatting of nested if

### DIFF
--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -120,16 +120,16 @@ impl Scanner {
         println!("Quick scanning: {}", path.display());
 
         // Special detection for EICAR test file
-        if let Ok(content) = fs::read_to_string(path) {
-            if content.contains("EICAR-STANDARD-ANTIVIRUS-TEST-FILE") {
-                return Ok(ScanResult {
-                    malicious: true,
-                    threat_name: Some("EICAR Test File".into()),
-                    file_hash: Some(
-                        "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f".into(),
-                    ),
-                });
-            }
+        if let Ok(content) = fs::read_to_string(path)
+            && content.contains("EICAR-STANDARD-ANTIVIRUS-TEST-FILE")
+        {
+            return Ok(ScanResult {
+                malicious: true,
+                threat_name: Some("EICAR Test File".into()),
+                file_hash: Some(
+                    "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f".into(),
+                ),
+            });
         }
 
         // Default case for regular files


### PR DESCRIPTION
## Description
I have collapsed the nested ```if``` mentioned in #95, the entire code block will eventually be removed as its part of a non hash based testing system

## Related Issue
Fixes #95 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Test improvement
- [ ] Other

## Checklist
- [x] I have read the Contributing Guidelines
- [x] My code follows the project's code style
- [ ] I have updated the documentation
- [ ] I have added tests to cover my changes
- [x] All new and existing tests pass
- [ ] I have checked for and resolved any merge conflicts

