### PR TITLE
fix(setup): installations now work with incompleate or eariler rust versions

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,6 +19,10 @@ RED="\033[0;31m"
 YELLOW="\033[1;33m"
 NC="\033[0m"  # No Color
 
+#Check Rust Version
+RUST_MSRV="1.85.0"
+
+
 PYTHON_VERSION="3.11"
 # Add all required Python libraries here
 REQUIRED_LIBRARIES=("requests" "pytest" "rich")
@@ -62,22 +66,82 @@ install_python_linux() {
 # Function to install Rust (stable) via rustup
 # ------------------------------------------
 install_rust() {
+  echo -e "${YELLOW}Checking Rust toolchain...${NC}"
+
+  # Install rustup if rustc is missing
   if ! command -v rustc &> /dev/null; then
     echo -e "${YELLOW}Rust not found. Installing via rustup...${NC}"
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
-    # Reload cargo env so this script can use cargo/rustc immediately
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --default-toolchain stable
     source "$HOME/.cargo/env"
-  else
-    echo -e "${GREEN}Rust found at: $(command -v rustc)${NC}"
-    # Ensure stable toolchain is installed but don't update
-    if ! rustup toolchain list | grep -q "stable"; then
-      echo -e "${YELLOW}Installing Rust stable toolchain...${NC}"
-      rustup toolchain install stable
-    fi
-    echo -e "${YELLOW}Setting Rust stable as default...${NC}"
-    rustup default stable
   fi
+
+  # rustup must exist if rustc exists
+  # throwing an error here beacuse if rust was installed in a different way 
+  # forcing an install cound cause 2 rust binares <- yikes
+  if ! command -v rustup &> /dev/null; then
+  echo -e "${YELLOW}rustc found but rustup missing. Installing rustup...${NC}"
+  
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable || {
+      echo -e "${RED}ERROR: Failed to install rustup.${NC}"
+      exit 1
+    }
+
+  source "$HOME/.cargo/env"
+
+  # Ensure rustup-installed rustc is first in PATH
+  if ! command -v rustup &> /dev/null; then
+    echo -e "${RED}ERROR: rustup installation succeeded but not in PATH.${NC}"
+    exit 1
+  fi
+fi
+
+  # Ensure stable toolchain is installed
+  if ! rustup toolchain list | grep -q "^stable"; then
+    echo -e "${YELLOW}Installing stable Rust toolchain...${NC}"
+    rustup toolchain install stable || {
+      echo -e "${RED}ERROR: Failed to install stable toolchain.${NC}"
+      exit 1
+    }
+  fi
+
+  # Force stable as default
+  CURRENT_TOOLCHAIN="$(rustup show active-toolchain | awk '{print $1}')"
+  if [[ "$CURRENT_TOOLCHAIN" != stable* ]]; then
+    echo -e "${YELLOW}Switching default Rust toolchain to stable...${NC}"
+    rustup default stable || {
+      echo -e "${RED}ERROR: Failed to set stable as default toolchain.${NC}"
+      exit 1
+    }
+  fi
+
+  # Update stable toolchain
+  echo -e "${YELLOW}Updating stable Rust toolchain...${NC}"
+  rustup update stable || {
+    echo -e "${RED}ERROR: Failed to update Rust stable toolchain.${NC}"
+    exit 1
+  }
+
+  # Check rustc version against MSRV
+  INSTALLED_VERSION="$(rustc --version | awk '{print $2}')"
+    if [[ "$(printf '%s\n' "$RUST_MSRV" "$INSTALLED_VERSION" | sort -V | head -n1)" != "$RUST_MSRV" ]]; then
+    echo -e "${YELLOW}Rust ${INSTALLED_VERSION} is below MSRV (${RUST_MSRV}). Updating stable...${NC}"
+    
+    INSTALLED_VERSION="$(rustc --version | awk '{print $2}')"
+
+    # There is an error if we "succesfully" updated but are still under MSRV
+    if [[ "$(printf '%s\n' "$RUST_MSRV" "$INSTALLED_VERSION" | sort -V | head -n1)" != "$RUST_MSRV" ]]; then
+      echo -e "${RED}ERROR: Rust is still below required version ${RUST_MSRV}.${NC}"
+      echo -e "${RED}Installed version: ${INSTALLED_VERSION}${NC}"
+      echo -e "${RED}Please check your network or rustup installation.${NC}"
+      exit 1
+    fi
+  fi
+
+  echo -e "${GREEN}Rust ${INSTALLED_VERSION} (stable) is ready.${NC}"
 }
+
 
 # ------------------------------------------
 # Install system dependencies for Rust crates


### PR DESCRIPTION
## Description
This PR elaborated on the current setup.sh rust setup function. It now woks with behind versions of rust as well as non-stable versions. It will also fail with an error if a situation that was unexpected arises, i.e. rust was installed without rustup, which is not easy to solve in a general way to my knowledge.

## Related Issue
Fixes #87 

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Refactoring / CI / Docs
- [ ] Other

## How to Test
I would recommend doing this in a shell as to not mess with your current rust environment:
- test the install on an existing rust environment (should just pass with all green)
- test on a behind version of rust (should update)
- test on a system without rust (should install)
- test on a system that had rust manually installed without rustup (Should exit with an error)
- test on a system that has rust in nightly or any other non stable version (Should reconfigure, but if rustup is not in the system it will error before it gets to this step)
- 

## Checklist
- [x] Code follows project style (`cargo fmt` + `cargo clippy`)
- [x] Tests added/updated and passing (`cargo test`)
- [ ] Documentation updated (if applicable)
