### PR TITLE
Fix: Changed &PathBuf to &Path in CLI handlers

### DIFF
--- a/src/cli/quarantine.rs
+++ b/src/cli/quarantine.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use anyhow::Result;
 use log::info;
@@ -31,8 +31,7 @@ pub fn handle_quarantine_command(id: &str) -> Result<()> {
 /// # Returns
 ///
 /// * `Result<()>` - Ok if the quarantine was successful, Err otherwise
-#[allow(clippy::ptr_arg)]
-pub fn handle_quarantine_file_command(path: &PathBuf, name: Option<String>) -> Result<()> {
+pub fn handle_quarantine_file_command(path: &Path, name: Option<String>) -> Result<()> {
     info!("Quarantining file at {}", path.display());
     let name = name.unwrap_or("".to_string());
     if !name.is_empty() {

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use anyhow::Result;
 use log::info;
@@ -32,8 +32,7 @@ pub fn handle_remove_command(id: &str, force: bool) -> Result<()> {
 /// # Returns
 ///
 /// * `Result<()>` - Ok if the removal was successful, Err otherwise
-#[allow(clippy::ptr_arg)]
-pub fn handle_remove_file_command(path: &PathBuf, force: bool) -> Result<()> {
+pub fn handle_remove_file_command(path: &Path, force: bool) -> Result<()> {
     info!(
         "Removing file at {}, without confirmation: {force}",
         path.display()

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use anyhow::Result;
 use log::info;
@@ -13,8 +13,7 @@ use log::info;
 /// # Returns
 ///
 /// * `Result<()>` - Ok if the scan was successful, Err otherwise
-#[allow(clippy::ptr_arg)]
-pub fn handle_scan_command(path: &PathBuf, deep: bool) -> Result<()> {
+pub fn handle_scan_command(path: &Path, deep: bool) -> Result<()> {
     info!(
         "Starting {} scan on path: {}",
         if deep { "deep" } else { "fast" },


### PR DESCRIPTION
## Description
Change &PathBuf to &Path in CLI handlers

## Related Issue
Fixes #140 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [X] Refactoring / CI / Docs
- [ ] Other

## How to Test
- cargo clippy --all-targets --all-features -- -D warnings passes with no ptr_arg warnings
- cargo test passes
- ./scripts/validate_strict.sh passes

## Checklist
- [X] Code follows project style (`cargo fmt` + `cargo clippy`)
- [X] Tests added/updated and passing (`cargo test`)
- [ ] Documentation updated (if applicable)
