### PR TITLE
Replace benchmarks with real benchmarks

### DIFF
--- a/benches/database_benchmark.rs
+++ b/benches/database_benchmark.rs
@@ -1,142 +1,160 @@
-use criterion::{Criterion, criterion_group, criterion_main};
+use chrono::Utc;
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use malware_minimizer::database::{
+    DatabaseManager, HashType, MalwareSeverity, MalwareSignature, Platform, SignatureDatabase,
+    SignatureType, signature_key,
+};
+use std::fs::File;
 use std::hint::black_box;
+use std::io::BufWriter;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
 
-// Simple benchmark function that will compile without errors
-fn bench_dummy(c: &mut Criterion) {
-    c.bench_function("dummy_db", |b| {
-        b.iter(|| {
-            // Dummy computation that will always compile
-            black_box(42 + 42)
-        })
-    });
+struct DatabaseBenchFile {
+    label: &'static str,
+    path: PathBuf,
+    signature_count: usize,
+    existing_hash: String,
+    missing_hash: String,
 }
 
-criterion_group!(benches, bench_dummy);
-criterion_main!(benches);
+fn make_signature(id: usize, hash: &str) -> MalwareSignature {
+    MalwareSignature {
+        id: format!("BENCH-SIG-{id:05}"),
+        name: format!("Benchmark Threat {id:05}"),
+        hash: hash.to_string(),
+        hash_type: HashType::Sha256,
+        signature_type: SignatureType::File,
+        partial_hashes: None,
+        severity: MalwareSeverity::Low,
+        description: "Synthetic benchmark signature".to_string(),
+        added_date: Utc::now(),
+        platforms: vec![Platform::Any],
+        tags: vec!["benchmark".to_string()],
+        url: None,
+        pattern: None,
+        source: Some("benchmark".to_string()),
+        source_id: None,
+    }
+}
 
-/* Original benchmarks - uncomment when modules are implemented
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
-use tempfile::TempDir;
-use std::path::PathBuf;
-use MalwareMinimizer::database::{DatabaseConfig, SignatureDatabase};
+fn write_database_file(dir: &Path, name: &str, signature_count: usize) -> DatabaseBenchFile {
+    let path = dir.join(name);
+    let mut database = SignatureDatabase::default();
 
-// Benchmark database operations
-fn bench_database(c: &mut Criterion) {
-    let temp_dir = TempDir::new().unwrap();
-    let db_path = temp_dir.path().join("test_signatures.db");
+    for id in 0..signature_count {
+        let hash = format!("{id:064x}");
+        database.signatures.insert(
+            signature_key(HashType::Sha256, &hash),
+            make_signature(id, &hash),
+        );
+    }
 
-    // Prepare test hashes
-    let test_hashes = [
-        "44d88612fea8a8f36de82e1278abb02f", // EICAR
-        "275a021bbfb6489e54d471899f7db9d1", // md5("test")
-        "5eb63bbbe01eeed093cb22bb8f5acdc3", // md5("hello world")
-        "098f6bcd4621d373cade4e832627b4f6", // md5("test")
-        "5d41402abc4b2a76b9719d911017c592", // md5("hello")
+    database.metadata.signature_count = signature_count;
+    database.metadata.hash_types = vec![HashType::Sha256];
+
+    let file = File::create(&path).expect("benchmark database file should be writable");
+    let writer = BufWriter::new(file);
+    serde_json::to_writer_pretty(writer, &database).expect("benchmark database should serialize");
+
+    DatabaseBenchFile {
+        label: match signature_count {
+            100 => "100-signatures",
+            10_000 => "10k-signatures",
+            _ => "custom-signatures",
+        },
+        path,
+        signature_count,
+        existing_hash: format!("{:064x}", signature_count / 2),
+        missing_hash: format!("{:064x}", signature_count + 1),
+    }
+}
+
+fn build_database_fixture() -> (TempDir, Vec<DatabaseBenchFile>) {
+    let temp_dir = TempDir::new().expect("tempdir should be created");
+    let files = vec![
+        write_database_file(temp_dir.path(), "db_small.json", 100),
+        write_database_file(temp_dir.path(), "db_large.json", 10_000),
     ];
 
-    // Initialize benchmark database with many signatures
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let db = rt.block_on(async {
-        let mut db = SignatureDatabase::with_path(&db_path);
+    (temp_dir, files)
+}
 
-        // Add test signatures
-        for (i, hash) in test_hashes.iter().enumerate() {
-            db.add_test_signature(hash, &format!("Test-Signature-{}", i)).await.unwrap();
-        }
+fn bench_load_database(c: &mut Criterion) {
+    let (_temp_dir, databases) = build_database_fixture();
+    let mut group = c.benchmark_group("Database/load_database");
+    group.sample_size(20);
 
-        // Add a bunch of additional signatures to make the database larger
-        for i in 0..10_000 {
-            let hash = format!("{:032x}", i);
-            db.add_test_signature(&hash, &format!("Padding-Signature-{}", i)).await.unwrap();
-        }
-
-        db
-    });
-
-    // Benchmark lookup performance
-    let mut group = c.benchmark_group("Database/Lookup");
-
-    for (i, hash) in test_hashes.iter().enumerate() {
-        group.bench_with_input(BenchmarkId::new("Lookup", i), hash, |b, hash| {
-            let db = db.clone();
-            let rt = tokio::runtime::Runtime::new().unwrap();
-
-            b.iter(|| {
-                rt.block_on(async {
-                    black_box(db.lookup_signature(hash).await.unwrap());
-                });
-            });
-        });
+    for bench_db in &databases {
+        group.throughput(Throughput::Elements(bench_db.signature_count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(bench_db.label),
+            bench_db,
+            |b, bench_db| {
+                b.iter_batched(
+                    || DatabaseManager::new(&bench_db.path),
+                    |mut manager| {
+                        black_box(
+                            manager
+                                .load_database()
+                                .expect("benchmark load should succeed")
+                                .metadata
+                                .signature_count,
+                        )
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
     }
-
-    // Also benchmark lookup for non-existent hash
-    group.bench_with_input(BenchmarkId::new("Lookup", "NonExistent"), &"nonexistenthash", |b, hash| {
-        let db = db.clone();
-        let rt = tokio::runtime::Runtime::new().unwrap();
-
-        b.iter(|| {
-            rt.block_on(async {
-                black_box(db.lookup_signature(hash).await.unwrap());
-            });
-        });
-    });
-
-    group.finish();
-
-    // Benchmark batch operation performance
-    let mut group = c.benchmark_group("Database/BatchOperations");
-
-    // Test batch lookup performance with different batch sizes
-    for batch_size in [10, 100, 1000].iter() {
-        // Create a batch of hashes
-        let batch: Vec<String> = (0..*batch_size)
-            .map(|i| format!("{:032x}", i))
-            .collect();
-
-        group.bench_with_input(BenchmarkId::new("BatchLookup", batch_size), &batch, |b, batch| {
-            let db = db.clone();
-            let rt = tokio::runtime::Runtime::new().unwrap();
-
-            b.iter(|| {
-                rt.block_on(async {
-                    for hash in batch {
-                        black_box(db.lookup_signature(hash).await.unwrap());
-                    }
-                });
-            });
-        });
-    }
-
-    group.finish();
-
-    // Benchmark database initialization
-    let mut group = c.benchmark_group("Database/Initialization");
-
-    group.bench_function("NewDatabase", |b| {
-        let temp_path = temp_dir.path().join("new_db.db");
-
-        b.iter(|| {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async {
-                let db = SignatureDatabase::with_path(&temp_path);
-                black_box(db.initialize().await.unwrap());
-            });
-        });
-    });
-
-    group.bench_function("LoadExistingDatabase", |b| {
-        b.iter(|| {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async {
-                let db = black_box(SignatureDatabase::with_path(&db_path));
-                black_box(db.load().await.unwrap());
-            });
-        });
-    });
 
     group.finish();
 }
 
-criterion_group!(benches, bench_database);
+fn bench_lookup_signature(c: &mut Criterion) {
+    let (_temp_dir, databases) = build_database_fixture();
+    let mut group = c.benchmark_group("Database/lookup_signature");
+
+    for bench_db in &databases {
+        let mut manager = DatabaseManager::new(&bench_db.path);
+        manager
+            .load_database()
+            .expect("benchmark lookup database should load");
+
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(
+            BenchmarkId::new("present", bench_db.label),
+            &bench_db.existing_hash,
+            |b, hash| {
+                b.iter(|| {
+                    black_box(
+                        manager
+                            .lookup_signature(HashType::Sha256, black_box(hash.as_str()))
+                            .expect("present lookup should succeed")
+                            .is_some(),
+                    )
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("missing", bench_db.label),
+            &bench_db.missing_hash,
+            |b, hash| {
+                b.iter(|| {
+                    black_box(
+                        manager
+                            .lookup_signature(HashType::Sha256, black_box(hash.as_str()))
+                            .expect("missing lookup should succeed")
+                            .is_some(),
+                    )
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_load_database, bench_lookup_signature);
 criterion_main!(benches);
-*/

--- a/benches/scanner_benchmark.rs
+++ b/benches/scanner_benchmark.rs
@@ -1,162 +1,101 @@
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use malware_minimizer::utils::hash::{HashType, Hasher};
+use std::fs::File;
 use std::hint::black_box;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
 
-// Simple benchmark function that will compile without errors
-fn bench_dummy(c: &mut Criterion) {
-    c.bench_function("dummy", |b| {
-        b.iter(|| {
-            // Dummy computation that will always compile
-            black_box(42 + 42)
-        })
-    });
+const ALL_HASH_TYPES: [HashType; 3] = [HashType::Sha256, HashType::Sha1, HashType::Md5];
+const WRITE_CHUNK_SIZE: usize = 64 * 1024;
+
+struct BenchFile {
+    label: &'static str,
+    path: PathBuf,
+    size_bytes: u64,
 }
 
-criterion_group!(benches, bench_dummy);
-criterion_main!(benches);
-
-/* Original benchmarks - uncomment when modules are implemented
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
-use std::path::Path;
-use std::fs::{self, File};
-use std::io::Write;
-use tempfile::TempDir;
-use MalwareMinimizer::scanner::{Scanner, ScannerConfig};
-
-/// Create a file with specified size
-fn create_test_file(dir: &Path, name: &str, size_kb: usize) -> std::path::PathBuf {
+fn create_test_file(dir: &Path, name: &str, size_bytes: usize) -> PathBuf {
     let file_path = dir.join(name);
-    let mut file = File::create(&file_path).unwrap();
+    let mut file = File::create(&file_path).expect("benchmark fixture should be writable");
+    let chunk = vec![0xAB; WRITE_CHUNK_SIZE];
+    let mut remaining = size_bytes;
 
-    // Create random content of specified size
-    let content = (0..size_kb * 1024)
-        .map(|_| fastrand::u8(..))
-        .collect::<Vec<u8>>();
+    while remaining > 0 {
+        let to_write = remaining.min(chunk.len());
+        file.write_all(&chunk[..to_write])
+            .expect("benchmark fixture write should succeed");
+        remaining -= to_write;
+    }
 
-    file.write_all(&content).unwrap();
+    file.sync_all()
+        .expect("benchmark fixture should flush to disk");
     file_path
 }
 
-fn bench_scanner(c: &mut Criterion) {
-    let temp_dir = TempDir::new().unwrap();
+fn build_hash_fixture() -> (TempDir, Vec<BenchFile>) {
+    let temp_dir = TempDir::new().expect("tempdir should be created");
+    let files = vec![
+        BenchFile {
+            label: "4KiB",
+            path: create_test_file(temp_dir.path(), "small.bin", 4 * 1024),
+            size_bytes: 4 * 1024,
+        },
+        BenchFile {
+            label: "1MiB",
+            path: create_test_file(temp_dir.path(), "medium.bin", 1024 * 1024),
+            size_bytes: 1024 * 1024,
+        },
+    ];
 
-    // Create test files of different sizes
-    let small_file = create_test_file(temp_dir.path(), "small.bin", 10);      // 10 KB
-    let medium_file = create_test_file(temp_dir.path(), "medium.bin", 1000);  // 1 MB
-    let large_file = create_test_file(temp_dir.path(), "large.bin", 10000);   // 10 MB
+    (temp_dir, files)
+}
 
-    // Create scanners with different configurations
-    let default_scanner = Scanner::new(ScannerConfig::default());
-    let deep_scanner = Scanner::new(ScannerConfig {
-        deep_scan: true,
-        ..ScannerConfig::default()
-    });
+fn bench_sha256(c: &mut Criterion) {
+    let (_temp_dir, files) = build_hash_fixture();
+    let mut group = c.benchmark_group("Hasher/sha256");
 
-    // Benchmark group for regular scan
-    let mut group = c.benchmark_group("Scanner/QuickScan");
-
-    // Benchmark quick scan with different file sizes
-    group.bench_with_input(BenchmarkId::new("SmallFile", "10KB"), &small_file, |b, file| {
-        let scanner = Scanner::new(ScannerConfig::default());
-        let rt = tokio::runtime::Runtime::new().unwrap();
-
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = black_box(scanner.scan_file(file).await);
-            });
-        });
-    });
-
-    group.bench_with_input(BenchmarkId::new("MediumFile", "1MB"), &medium_file, |b, file| {
-        let scanner = Scanner::new(ScannerConfig::default());
-        let rt = tokio::runtime::Runtime::new().unwrap();
-
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = black_box(scanner.scan_file(file).await);
-            });
-        });
-    });
-
-    group.bench_with_input(BenchmarkId::new("LargeFile", "10MB"), &large_file, |b, file| {
-        let scanner = Scanner::new(ScannerConfig::default());
-        let rt = tokio::runtime::Runtime::new().unwrap();
-
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = black_box(scanner.scan_file(file).await);
-            });
-        });
-    });
-
-    group.finish();
-
-    // Benchmark group for deep scan
-    let mut group = c.benchmark_group("Scanner/DeepScan");
-
-    // Benchmark deep scan with different file sizes
-    group.bench_with_input(BenchmarkId::new("SmallFile", "10KB"), &small_file, |b, file| {
-        let scanner = Scanner::new(ScannerConfig {
-            deep_scan: true,
-            ..ScannerConfig::default()
-        });
-        let rt = tokio::runtime::Runtime::new().unwrap();
-
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = black_box(scanner.scan_file(file).await);
-            });
-        });
-    });
-
-    group.bench_with_input(BenchmarkId::new("MediumFile", "1MB"), &medium_file, |b, file| {
-        let scanner = Scanner::new(ScannerConfig {
-            deep_scan: true,
-            ..ScannerConfig::default()
-        });
-        let rt = tokio::runtime::Runtime::new().unwrap();
-
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = black_box(scanner.scan_file(file).await);
-            });
-        });
-    });
-
-    // Don't benchmark deep scan on large files as that would take too long
-
-    group.finish();
-
-    // Benchmark comparison between normal and deep scan
-    let mut group = c.benchmark_group("Scanner/Comparison");
-
-    group.bench_function("QuickScan/MediumFile", |b| {
-        let scanner = Scanner::new(ScannerConfig::default());
-        let rt = tokio::runtime::Runtime::new().unwrap();
-
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = black_box(scanner.scan_file(&medium_file).await);
-            });
-        });
-    });
-
-    group.bench_function("DeepScan/MediumFile", |b| {
-        let scanner = Scanner::new(ScannerConfig {
-            deep_scan: true,
-            ..ScannerConfig::default()
-        });
-        let rt = tokio::runtime::Runtime::new().unwrap();
-
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = black_box(scanner.scan_file(&medium_file).await);
-            });
-        });
-    });
+    for bench_file in &files {
+        group.throughput(Throughput::Bytes(bench_file.size_bytes));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(bench_file.label),
+            bench_file,
+            |b, bench_file| {
+                b.iter(|| {
+                    black_box(
+                        Hasher::sha256(black_box(&bench_file.path))
+                            .expect("benchmark hashing should succeed"),
+                    )
+                });
+            },
+        );
+    }
 
     group.finish();
 }
 
-criterion_group!(benches, bench_scanner);
+fn bench_multi_hash(c: &mut Criterion) {
+    let (_temp_dir, files) = build_hash_fixture();
+    let mut group = c.benchmark_group("Hasher/multi_hash");
+
+    for bench_file in &files {
+        group.throughput(Throughput::Bytes(bench_file.size_bytes));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(bench_file.label),
+            bench_file,
+            |b, bench_file| {
+                b.iter(|| {
+                    black_box(
+                        Hasher::multi_hash(black_box(&bench_file.path), black_box(&ALL_HASH_TYPES))
+                            .expect("benchmark multi-hash should succeed"),
+                    )
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_sha256, bench_multi_hash);
 criterion_main!(benches);
-*/


### PR DESCRIPTION
## Description
Updates the trivial 42+42 test with real benchmark tests to be able to properly benchmark our performance of the database and scanner. No production code changed.


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / CI / Docs
- [ ] Other

## How to Test
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-targets --all-features
cargo test --all-targets --all-features -- --ignored
cargo test --doc --release
cargo bench --bench scanner_benchmark -- --sample-size 10
cargo bench --bench database_benchmark -- --sample-size 10

## Checklist
- [x] Code follows project style (`cargo fmt` + `cargo clippy`)
- [x] Tests added/updated and passing (`cargo test`)
- [x] Documentation updated (if applicable)
