### PR TITLE
feat(quarantine): add manifest load/save helpers

### DIFF
--- a/src/quarantine/entry.rs
+++ b/src/quarantine/entry.rs
@@ -1,11 +1,12 @@
 use std::fmt;
+use std::fs::File;
+use std::io::{BufReader, BufWriter, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
+use anyhow::Context;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use std::fs::{File};
-use std::io::{BufReader, BufWriter};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct QuarantineEntry {
@@ -98,14 +99,50 @@ impl QuarantineManifest {
             .position(|entry| entry.id == id)
             .map(|index| self.entries.swap_remove(index))
     }
+
+    /// Load the persisted quarantine manifest from disk.
+    pub fn load_from_path(path: &Path) -> anyhow::Result<Self> {
+        let file = match File::open(path) {
+            Ok(file) => file,
+            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(Self::new()),
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!("failed to open quarantine manifest at {}", path.display())
+                });
+            }
+        };
+
+        let reader = BufReader::new(file);
+        serde_json::from_reader(reader)
+            .with_context(|| format!("failed to parse quarantine manifest at {}", path.display()))
+    }
+
+    /// Save the quarantine manifest to disk as stable pretty-printed JSON.
+    pub fn save_to_path(&self, path: &Path) -> anyhow::Result<()> {
+        let file = File::create(path).with_context(|| {
+            format!("failed to create quarantine manifest at {}", path.display())
+        })?;
+        let mut writer = BufWriter::new(file);
+        serde_json::to_writer_pretty(&mut writer, self).with_context(|| {
+            format!(
+                "failed to serialize quarantine manifest to {}",
+                path.display()
+            )
+        })?;
+        writer
+            .flush()
+            .with_context(|| format!("failed to flush quarantine manifest at {}", path.display()))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{QuarantineEntry, QuarantineManifest};
+    use std::fs;
     use std::path::{Path, PathBuf};
 
     use chrono::{DateTime, Utc};
+    use tempfile::tempdir;
     use uuid::Uuid;
 
     fn fixed_timestamp() -> DateTime<Utc> {
@@ -233,23 +270,139 @@ mod tests {
         assert!(manifest.find_by_id(&entry.id).is_none());
         assert!(manifest.remove_by_id(&entry.id).is_none());
     }
+
+    #[test]
+    fn load_from_path_reads_persisted_entries_correctly() {
+        let tempdir = tempdir().expect("tempdir should be created");
+        let manifest_path = tempdir.path().join("manifest.json");
+
+        fs::write(
+            &manifest_path,
+            r#"{
+  "entries": [
+    {
+      "id": "abc12345-6789-4def-8123-abcdef123456",
+      "original_path": "/tmp/original.exe",
+      "quarantined_path": "/tmp/quarantine/original.exe",
+      "file_hash": "deadbeef",
+      "threat_name": "EICAR",
+      "quarantined_at": "2024-01-15T12:34:56Z",
+      "file_size": 42,
+      "original_permissions": 416
+    }
+  ],
+  "version": 1
+}"#,
+        )
+        .expect("manifest should be written");
+
+        let manifest =
+            QuarantineManifest::load_from_path(&manifest_path).expect("manifest should load");
+
+        assert_eq!(manifest.version, 1);
+        assert_eq!(manifest.entries.len(), 1);
+        assert_eq!(
+            manifest.entries[0].id,
+            "abc12345-6789-4def-8123-abcdef123456"
+        );
+        assert_eq!(
+            manifest.entries[0].original_path,
+            Path::new("/tmp/original.exe")
+        );
+        assert_eq!(
+            manifest.entries[0].quarantined_path,
+            Path::new("/tmp/quarantine/original.exe")
+        );
+        assert_eq!(manifest.entries[0].file_hash, "deadbeef");
+        assert_eq!(manifest.entries[0].threat_name.as_deref(), Some("EICAR"));
+        assert_eq!(manifest.entries[0].quarantined_at, fixed_timestamp());
+        assert_eq!(manifest.entries[0].file_size, 42);
+        assert_eq!(manifest.entries[0].original_permissions, Some(0o640));
+    }
+
+    #[test]
+    fn save_to_path_writes_deterministic_valid_json() {
+        let tempdir = tempdir().expect("tempdir should be created");
+        let first_path = tempdir.path().join("manifest-first.json");
+        let second_path = tempdir.path().join("manifest-second.json");
+
+        let mut manifest = QuarantineManifest::new();
+        manifest.add(sample_entry());
+
+        manifest
+            .save_to_path(&first_path)
+            .expect("first manifest save should succeed");
+        manifest
+            .save_to_path(&second_path)
+            .expect("second manifest save should succeed");
+
+        let first_contents =
+            fs::read_to_string(&first_path).expect("first manifest file should be readable");
+        let second_contents =
+            fs::read_to_string(&second_path).expect("second manifest file should be readable");
+
+        assert_eq!(
+            first_contents, second_contents,
+            "serializing the same manifest twice should produce identical JSON"
+        );
+
+        let json: serde_json::Value =
+            serde_json::from_str(&first_contents).expect("saved manifest should be valid JSON");
+        assert_eq!(json["version"], 1);
+        assert_eq!(json["entries"].as_array().map(Vec::len), Some(1));
+    }
+
+    #[test]
+    fn load_from_path_returns_empty_manifest_when_file_is_missing() {
+        let tempdir = tempdir().expect("tempdir should be created");
+        let manifest_path = tempdir.path().join("missing-manifest.json");
+
+        let manifest =
+            QuarantineManifest::load_from_path(&manifest_path).expect("missing manifest is empty");
+
+        assert_eq!(manifest.version, 1);
+        assert!(manifest.entries.is_empty());
+    }
+
+    #[test]
+    fn save_and_load_round_trip_manifest() {
+        let tempdir = tempdir().expect("tempdir should be created");
+        let manifest_path = tempdir.path().join("manifest.json");
+
+        let mut manifest = QuarantineManifest::new();
+        manifest.add(sample_entry());
+
+        manifest
+            .save_to_path(&manifest_path)
+            .expect("manifest save should succeed");
+
+        let loaded =
+            QuarantineManifest::load_from_path(&manifest_path).expect("manifest should reload");
+
+        assert_eq!(loaded.version, manifest.version);
+        assert_eq!(loaded.entries.len(), manifest.entries.len());
+        assert_eq!(loaded.entries[0].id, manifest.entries[0].id);
+        assert_eq!(
+            loaded.entries[0].original_path,
+            manifest.entries[0].original_path
+        );
+        assert_eq!(
+            loaded.entries[0].quarantined_path,
+            manifest.entries[0].quarantined_path
+        );
+        assert_eq!(loaded.entries[0].file_hash, manifest.entries[0].file_hash);
+        assert_eq!(
+            loaded.entries[0].threat_name,
+            manifest.entries[0].threat_name
+        );
+        assert_eq!(
+            loaded.entries[0].quarantined_at,
+            manifest.entries[0].quarantined_at
+        );
+        assert_eq!(loaded.entries[0].file_size, manifest.entries[0].file_size);
+        assert_eq!(
+            loaded.entries[0].original_permissions,
+            manifest.entries[0].original_permissions
+        );
+    }
 }
-
-
-
-pub fn load_from_path(path: impl AsRef<Path>) -> anyhow::Result<QuarantineManifest> {
-    let path = path.as_ref();
-    let file = File::open(path)?;
-    let reader = BufReader::new(file);
-    let manifest: QuarantineManifest = serde_json::from_reader(reader)?;
-    Ok(manifest)
-}
-
-pub fn save_to_path(manifest: &QuarantineManifest, path: impl AsRef<Path>) -> anyhow::Result<()> {
-    let path = path.as_ref();
-    let file = File::create(path)?;
-    let writer = BufWriter::new(file);
-    serde_json::to_writer_pretty(writer, manifest)?;
-    Ok(())
-}
-


### PR DESCRIPTION
## Description
Add the quarantine manifest persistence helpers required by issue #192.
- add manifest load helper behavior on `QuarantineManifest`
- add manifest save helper behavior on `QuarantineManifest`
- treat a missing manifest file as an empty manifest
- add focused tests for persisted-load, deterministic-save, and round-trip behavior

## Related Issue
Fixes #192

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring / CI / Docs
- [ ] Other

## How to Test
- `cargo test quarantine::entry::tests -- --nocapture`
- `./scripts/validate_strict.sh`

## Checklist
- [x] Code follows project style (`cargo fmt` + `cargo clippy`)
- [x] Tests added/updated and passing (`cargo test`)
- [x] Documentation updated (not applicable; no user-facing behavior changed)