### PR TITLE
test(database): add MVP lookup and persistence coverage

### DIFF
--- a/.review-commands.txt
+++ b/.review-commands.txt
@@ -1,0 +1,2 @@
+# Issue #212 targeted database unit coverage
+cargo test database::operations::tests --lib -- --nocapture

--- a/docs/execution-plans/issue-212-database-unit-tests.md
+++ b/docs/execution-plans/issue-212-database-unit-tests.md
@@ -1,0 +1,71 @@
+# Execution Plan: issue-212 database unit tests
+
+## Goal
+
+- Add deterministic unit-test coverage for the current MVP database manager's lookup and persistence behavior so issue #212 can merge without depending on unrelated feature work.
+
+## Scope
+
+- In scope:
+- Add database module unit tests for positive lookup, negative lookup, and persistence/load behavior against local temporary fixtures.
+- Reuse the current MVP database API as implemented in `DatabaseManager`.
+- Capture validation evidence for the issue acceptance criteria.
+- Out of scope:
+- Database schema redesign or updater CLI work from related issues.
+- New production behavior in the database manager beyond what the tests require.
+
+## Inputs
+
+- Issue/PR:
+- [Issue #212](https://github.com/Jordan231111/MalwareMinimizer/issues/212)
+- Related docs:
+- `docs/contributing-guidelines.md`
+- `docs/development-guide.md`
+- `tests/README.md`
+- `docs/architecture-documentation.md`
+- `docs/Comprehensive_Plan_2026.txt`
+- Constraints:
+- Local-only, deterministic fixtures only.
+- No real malware samples.
+- Validation must include repository baseline checks and task-specific commands.
+
+## Acceptance Criteria Checklist
+
+- [x] A positive lookup path is covered by a unit test
+- [x] A negative lookup path is covered by a unit test
+- [x] Persistence/load behavior is covered where the current MVP API supports it
+- [x] Tests use local-only fixtures and are deterministic
+
+## Plan
+
+1. Confirm issue #212 is independently actionable against the current database API and identify the minimal unit-test seam in `src/database/operations.rs`.
+2. Add focused unit tests that create temporary local database fixtures, exercise lookup behavior, and verify persistence across a reload.
+3. Run strict validation plus task-specific database test commands, then update this plan with concrete verification evidence.
+
+## Verification Matrix
+
+| Criterion | Verification Method | Evidence | Status |
+|---|---|---|---|
+| Positive lookup unit test | Targeted unit test command | `cargo test database::operations::tests --lib -- --nocapture` ran `lookup_signature_finds_inserted_and_updated_signature` successfully | Pass |
+| Negative lookup unit test | Targeted unit test command | `cargo test database::operations::tests --lib -- --nocapture` ran `lookup_signature_returns_none_for_unknown_hash` successfully | Pass |
+| Persistence/load coverage | Targeted unit test command | `cargo test database::operations::tests --lib -- --nocapture` ran `add_signature_persists_across_reload` successfully | Pass |
+| Deterministic local fixtures | Code review + strict validation | Tests in `src/database/operations.rs` use only `tempdir()` and fixed hash constants; `./scripts/validate_strict.sh .review-commands.txt` passed | Pass |
+
+
+Rule: if a targeted `cargo test` command executed zero tests, record it as `Fail`, not `Pass`.
+Rule: if a required check was already failing before the reviewed change, record it separately as a pre-existing blocker instead of attributing it to the change.
+
+## Risks And Mitigations
+
+- Risk: Existing integration tests already cover similar behavior, so unit tests could become redundant rather than additive.
+- Mitigation: Keep the new tests narrow and colocated with `DatabaseManager` so they verify module behavior directly without duplicating updater/network coverage.
+
+## Rollback / Recovery
+
+- Revert the new unit tests and execution-plan file if they prove flaky or duplicate invalid assumptions about the current API.
+
+## Final Notes
+
+- Related tracking issue `#164` explicitly says to complete child issue `#212`, so this work is not blocked by the tracking issue itself.
+- Related issue `#155` covers updater CLI wiring and is not a prerequisite for these database manager unit tests.
+- Repository baseline was green before the change via `./scripts/validate_strict.sh`, so no pre-existing blocker was masking this work.

--- a/src/database/operations.rs
+++ b/src/database/operations.rs
@@ -306,3 +306,163 @@ impl DatabaseManager {
         out
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use anyhow::Result;
+    use chrono::Utc;
+    use tempfile::tempdir;
+
+    use super::DatabaseManager;
+    use crate::database::schema::{
+        MalwareSeverity, MalwareSignature, Platform, SignatureDatabase, SignatureType,
+        signature_key,
+    };
+    use crate::utils::hash::HashType;
+
+    const INSERTED_HASH: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+    const PERSISTED_HASH: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const MISSING_HASH: &str = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
+    fn make_signature(id: &str, name: &str, hash: &str, hash_type: HashType) -> MalwareSignature {
+        MalwareSignature {
+            id: id.to_string(),
+            name: name.to_string(),
+            hash: hash.to_string(),
+            hash_type,
+            signature_type: SignatureType::File,
+            partial_hashes: None,
+            severity: MalwareSeverity::Medium,
+            description: "Database unit test fixture".to_string(),
+            added_date: Utc::now(),
+            platforms: vec![Platform::Any],
+            tags: vec!["test".to_string()],
+            url: None,
+            pattern: None,
+            source: Some("unit-test".to_string()),
+            source_id: None,
+        }
+    }
+
+    #[test]
+    fn lookup_signature_finds_inserted_and_updated_signature() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let db_path = temp_dir.path().join("signatures.json");
+        let mut manager = DatabaseManager::new(&db_path);
+
+        let initial_count = manager.get_database()?.metadata.signature_count;
+
+        manager.add_signature(make_signature(
+            "TEST-INSERT-001",
+            "Original threat",
+            INSERTED_HASH,
+            HashType::Sha256,
+        ))?;
+        {
+            let db = manager.get_database()?;
+            assert_eq!(db.metadata.signature_count, initial_count + 1);
+        }
+        {
+            let signature = manager
+                .lookup_signature(HashType::Sha256, &INSERTED_HASH.to_uppercase())?
+                .expect("inserted signature should be found");
+            assert_eq!(signature.id, "TEST-INSERT-001");
+            assert_eq!(signature.name, "Original threat");
+        }
+
+        manager.add_signature(make_signature(
+            "TEST-INSERT-002",
+            "Updated threat",
+            INSERTED_HASH,
+            HashType::Sha256,
+        ))?;
+        {
+            let db = manager.get_database()?;
+            assert_eq!(
+                db.metadata.signature_count,
+                initial_count + 1,
+                "re-inserting the same canonical hash should update in place"
+            );
+        }
+        {
+            let signature = manager
+                .lookup_signature(HashType::Sha256, INSERTED_HASH)?
+                .expect("updated signature should still be found");
+            assert_eq!(signature.id, "TEST-INSERT-002");
+            assert_eq!(signature.name, "Updated threat");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn lookup_signature_returns_none_for_unknown_hash() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let db_path = temp_dir.path().join("signatures.json");
+        let mut manager = DatabaseManager::new(&db_path);
+
+        manager.get_database()?;
+
+        let missing = manager.lookup_signature(HashType::Sha256, MISSING_HASH)?;
+        assert!(
+            missing.is_none(),
+            "unknown hash should not resolve to a signature"
+        );
+
+        let wrong_type = manager.lookup_signature(
+            HashType::Md5,
+            "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+        )?;
+        assert!(
+            wrong_type.is_none(),
+            "same hash value with a different hash type should not match"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn add_signature_persists_across_reload() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let db_path = temp_dir.path().join("signatures.json");
+        let mut manager = DatabaseManager::new(&db_path);
+
+        manager.add_signature(make_signature(
+            "TEST-PERSIST-001",
+            "Persisted threat",
+            PERSISTED_HASH,
+            HashType::Sha1,
+        ))?;
+
+        let on_disk: SignatureDatabase = serde_json::from_str(&fs::read_to_string(&db_path)?)?;
+        assert!(
+            on_disk
+                .signatures
+                .contains_key(&signature_key(HashType::Sha1, PERSISTED_HASH))
+        );
+        assert!(
+            on_disk.metadata.hash_types.contains(&HashType::Sha1),
+            "persisted metadata should record the inserted hash type"
+        );
+
+        let mut reloaded = DatabaseManager::new(&db_path);
+        {
+            let db = reloaded.load_database()?;
+            assert_eq!(
+                db.metadata.signature_count, on_disk.metadata.signature_count,
+                "reloaded database should preserve the persisted signature count"
+            );
+        }
+        {
+            let signature = reloaded
+                .lookup_signature(HashType::Sha1, PERSISTED_HASH)?
+                .expect("reloaded signature should be found");
+            assert_eq!(signature.id, "TEST-PERSIST-001");
+            assert_eq!(signature.name, "Persisted threat");
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description
- add focused `DatabaseManager` unit coverage for positive lookup and same-hash update semantics
- add deterministic negative lookup coverage for missing hashes and hash-type mismatches
- add persistence/reload round-trip coverage using local temporary fixtures only
- document the execution plan and task-specific validation command for reviewers

## Related Issue
Closes #212

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / CI / Docs
- [x] Other

## How to Test
```bash
./scripts/validate_strict.sh .review-commands.txt
```

## Acceptance Criteria Evidence
- Positive lookup path: `lookup_signature_finds_inserted_and_updated_signature`
- Negative lookup path: `lookup_signature_returns_none_for_unknown_hash`
- Persistence/load path: `add_signature_persists_across_reload`
- Deterministic fixtures: tests use `tempdir()` plus fixed hash constants only

## Checklist
- [x] Code follows project style (`cargo fmt` + `cargo clippy`)
- [x] Tests added/updated and passing (`cargo test`)
- [x] Documentation updated (if applicable)
