### PR TITLE
Feature/quarantine manager

### DIFF
--- a/src/quarantine/manager.rs
+++ b/src/quarantine/manager.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use anyhow::{Result, anyhow};
 #[cfg(unix)]
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::fs::PermissionsExt;
 use std::{
     fs::{self, rename},
     io,
@@ -20,13 +20,21 @@ pub struct QuarantineManager {
 
 impl QuarantineManager {
     pub fn new(quarantine_dir: &Path) -> Result<Self> {
+        let manifest_path = quarantine_dir.join("quarantine.json");
+        if !quarantine_dir.exists() {
+            std::fs::create_dir_all(quarantine_dir)?;
+            #[cfg(unix)]
+            quarantine_dir.metadata()?.permissions().set_mode(0o700);
+        }
+        if !manifest_path.exists() {
+            drop(std::fs::File::create(&manifest_path));
+            QuarantineManifest::new().save_to_path(manifest_path.as_path())?;
+        }
         Ok(Self {
             dir: quarantine_dir.to_path_buf(),
             // For now presuming that the json will be stored in the quarantine directory
-            json: quarantine_dir.join("quarantine.json"),
-            manifest: QuarantineManifest::load_from_path(
-                quarantine_dir.join("quarantine.json").as_path(),
-            )?,
+            json: manifest_path.to_path_buf(),
+            manifest: QuarantineManifest::load_from_path(&manifest_path)?,
         })
     }
 
@@ -89,36 +97,15 @@ impl QuarantineManager {
         self.manifest.entries.clone()
     }
 
-    #[cfg(unix)]
-    pub fn quarantine_file(
-        &mut self,
-        path: &Path,
-        detection_name: &str,
-    ) -> Result<QuarantineEntry> {
-        let target_path: PathBuf = self.dir.join(
-            path.file_name()
-                .ok_or_else(|| anyhow!("Can not quarantine a non file"))?,
-        );
-        let hash: String = Hasher::sha256(path)?;
-        let file_data: std::fs::Metadata = path.metadata()?;
-        let perm = Some(file_data.permissions().mode());
-
-        QuarantineManager::move_file(path, &target_path)?;
-        QuarantineManager::set_file_perm(&target_path, 0o600)?;
-        let entry = QuarantineEntry::new(
-            path,
-            &target_path,
-            &hash,
-            Some(detection_name.to_string()),
-            file_data.size(),
-            perm,
-        );
-        self.manifest.add(entry.clone());
-        self.manifest.save_to_path(self.json.as_path())?;
-        Ok(entry)
+    fn already_quarantined(&self, path: &Path) -> bool {
+        for entry in self.manifest.entries.iter() {
+            if entry.quarantined_path == path {
+                return true;
+            }
+        }
+        false
     }
 
-    #[cfg(not(unix))]
     pub fn quarantine_file(
         &mut self,
         path: &Path,
@@ -128,8 +115,15 @@ impl QuarantineManager {
             path.file_name()
                 .ok_or_else(|| anyhow!("Can not quarantine a non file"))?,
         );
+        if self.already_quarantined(path) {
+            return Err(anyhow!("File already quarantined"));
+        }
         let hash: String = Hasher::sha256(path)?;
         let file_data: std::fs::Metadata = path.metadata()?;
+        #[cfg(unix)]
+        let perm = Some(file_data.permissions().mode());
+
+        #[cfg(not(unix))]
         let perm = {
             // Follows the logic outlined in set_file_perm
             if file_data.permissions().readonly() {
@@ -138,9 +132,8 @@ impl QuarantineManager {
                 Some(0)
             }
         };
-
         QuarantineManager::move_file(path, &target_path)?;
-        QuarantineManager::set_file_perm(&target_path, 1)?;
+        QuarantineManager::set_file_perm(&target_path, 0o600)?;
         let entry = QuarantineEntry::new(
             path,
             &target_path,


### PR DESCRIPTION
## Description
Implemented the changes proposed in #151, mostly following the outlined function prototypes and requirements. For all the edges cases I caught them and propagated an error up to the client. I leave implementation of what to do to the CLI. A lot of the code involving permissions is very messy due to the differences between unix and windows. It might be worth looking into a more OS agnostics method to achieve what we want. In implementing this I noticed a problem with how we handle original file permissions as there was no system suggested for restoring windows file permissions which we do edit as part of making a file read only. This required me to implement a very janky system  to deal with how we store permissions and should be fixed/changed in a later issue.

## Related Issue
Fixes #151

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / CI / Docs
- [ ] Other

## How to Test
```
cargo test quarantine_tests
```

## Checklist
- [x] Code follows project style (`cargo fmt` + `cargo clippy`)
- [x] Tests added/updated and passing (`cargo test`)
- [x] Documentation updated (if applicable)
