### PR TITLE
Feat/remove command clean

### DIFF
--- a/docs/CLI_USER_DOC.md
+++ b/docs/CLI_USER_DOC.md
@@ -116,8 +116,8 @@ Below is a list of common commands available in MalwareMinimizer.
   ```
 
 - **remove-file**  
-  Exposed in the CLI parser, but direct delete-by-path is still a placeholder
-  implementation. Prefer quarantining first, then using `remove --id`.
+  Permanently deletes a file by path using standard filesystem deletion.
+  This does not securely wipe file contents in v1.
   ```bash
   malware_minimizer remove-file --path <file_path> [--force]
   ```

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -5,6 +5,7 @@ use crate::{
     utils::{confirm, resolve},
 };
 use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Local};
 use log::info;
 
 /// Handles the remove command
@@ -70,9 +71,50 @@ pub(crate) fn handle_remove_file_command(path: &Path, force: bool) -> Result<()>
         path.display()
     );
 
-    // TODO(#154/#195/#209): replace this placeholder with direct delete-by-path
-    // behavior and shared confirmation handling once the removal lane is
-    // implemented for the MVP.
-    println!("Removal completed successfully!");
-    Ok(())
+    if !path.exists() {
+        anyhow::bail!("File at {} does not exist", path.display());
+    }
+
+    if path.is_dir() {
+        anyhow::bail!("Path {} is a directory, expected a file", path.display());
+    }
+
+    let metadata = path
+        .metadata()
+        .with_context(|| format!("failed to read metadata for {}", path.display()))?;
+    let modified: DateTime<Local> = metadata
+        .modified()
+        .with_context(|| format!("failed to read modification time for {}", path.display()))?
+        .into();
+    print_remove_file_details(path, &metadata, modified);
+
+    let prompt = format!("Permanently delete file {}?", path.display());
+    if !confirm(&prompt, force).context("failed to read removal confirmation")? {
+        println!("Removal cancelled; file left untouched.");
+        return Ok(());
+    }
+
+    match std::fs::remove_file(path) {
+        Ok(_) => {
+            println!("Removal completed successfully!");
+            Ok(())
+        }
+        Err(err) => match err.kind() {
+            std::io::ErrorKind::PermissionDenied => {
+                bail!("Permission denied while deleting {}", path.display())
+            }
+            std::io::ErrorKind::IsADirectory => {
+                bail!("Path {} is a directory, expected a file", path.display())
+            }
+            std::io::ErrorKind::NotFound => bail!("File at {} does not exist", path.display()),
+            _ => Err(err).with_context(|| format!("failed to delete {}", path.display())),
+        },
+    }
+}
+
+fn print_remove_file_details(path: &Path, metadata: &std::fs::Metadata, modified: DateTime<Local>) {
+    println!("File details:");
+    println!("Path: {}", path.display());
+    println!("Size: {} bytes", metadata.len());
+    println!("Last modified: {}", modified.format("%m/%d/%Y %T"));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,10 @@ enum Commands {
         force: bool,
     },
 
-    /// Remove the file at the given path
+    #[command(
+        about = "Remove the file at the given path",
+        long_about = "Remove the file at the given path.\n\nMalwareMinimizer uses standard filesystem deletion for this command in v1 and does not securely wipe file contents."
+    )]
     RemoveFile {
         /// Path to file
         #[arg(short, long, value_hint = clap::ValueHint::AnyPath)]

--- a/tests/cli_modernization_cli.rs
+++ b/tests/cli_modernization_cli.rs
@@ -419,14 +419,13 @@ fn restore_accepts_id_and_force_flags() {
 }
 
 #[test]
-fn remove_file_accepts_path_and_force_flags() {
-    let dir = tempdir().expect("tempdir should be created");
-    let test_file = dir.path().join("to-remove.bin");
-    fs::write(&test_file, b"sample").expect("test file should be created");
-    let path = test_file.to_string_lossy().to_string();
-
+fn remove_file_help_mentions_force_flag_and_no_secure_wipe_warning() {
     let mut cmd = cargo_bin_cmd!("malware_minimizer");
-    cmd.args(["remove-file", "--path", &path, "--force"]);
-    let output = cmd.output().expect("remove-file command should execute");
-    assert_no_clap_parse_error(&output, "remove-file");
+    cmd.args(["remove-file", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--force"))
+        .stdout(predicate::str::contains(
+            "does not securely wipe file contents",
+        ));
 }

--- a/tests/remove_file_cli.rs
+++ b/tests/remove_file_cli.rs
@@ -1,0 +1,96 @@
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::fs;
+#[cfg(unix)]
+use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+use tempfile::tempdir;
+
+fn write_fixture(path: &std::path::Path, contents: &[u8]) {
+    fs::write(path, contents).expect("fixture should be written");
+}
+
+#[test]
+fn remove_file_blank_confirmation_cancels_without_deleting() {
+    let dir = tempdir().expect("tempdir should be created");
+    let file_path = dir.path().join("keep.bin");
+    write_fixture(&file_path, b"sample");
+
+    let mut cmd = cargo_bin_cmd!("malware_minimizer");
+    cmd.args(["remove-file", "--path"])
+        .arg(&file_path)
+        .write_stdin("\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("File details:"))
+        .stdout(predicate::str::contains(format!(
+            "Path: {}",
+            file_path.display()
+        )))
+        .stdout(predicate::str::contains("Size: 6 bytes"))
+        .stdout(predicate::str::contains("Last modified:"))
+        .stdout(predicate::str::contains(format!(
+            "Permanently delete file {}? [y/N]",
+            file_path.display()
+        )))
+        .stdout(predicate::str::contains(
+            "Removal cancelled; file left untouched.",
+        ));
+
+    assert!(
+        file_path.exists(),
+        "blank confirmation should keep the file in place"
+    );
+}
+
+#[test]
+fn remove_file_yes_confirmation_deletes_file() {
+    let dir = tempdir().expect("tempdir should be created");
+    let file_path = dir.path().join("delete-me.bin");
+    write_fixture(&file_path, b"sample");
+
+    let mut cmd = cargo_bin_cmd!("malware_minimizer");
+    cmd.args(["remove-file", "--path"])
+        .arg(&file_path)
+        .write_stdin("yes\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("File details:"))
+        .stdout(predicate::str::contains("Removal completed successfully!"));
+
+    assert!(
+        !file_path.exists(),
+        "confirmed deletion should remove the file"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn remove_file_surfaces_permission_denied_errors() {
+    let dir = tempdir().expect("tempdir should be created");
+    let blocked_dir = dir.path().join("blocked");
+    let blocked_file = blocked_dir.join("locked.bin");
+    fs::create_dir_all(&blocked_dir).expect("blocked dir should be created");
+    write_fixture(&blocked_file, b"locked");
+    fs::set_permissions(&blocked_dir, Permissions::from_mode(0o555))
+        .expect("blocked dir should become read-only");
+
+    let mut cmd = cargo_bin_cmd!("malware_minimizer");
+    let assert = cmd
+        .args(["remove-file", "--path"])
+        .arg(&blocked_file)
+        .arg("--force")
+        .assert();
+
+    fs::set_permissions(&blocked_dir, Permissions::from_mode(0o755))
+        .expect("blocked dir permissions should be restorable");
+
+    assert.failure().stderr(predicate::str::contains(format!(
+        "Permission denied while deleting {}",
+        blocked_file.display()
+    )));
+
+    assert!(
+        blocked_file.exists(),
+        "permission-denied removal should leave the file in place"
+    );
+}


### PR DESCRIPTION
## Description
Added the remove file by path command as described in issue #154. Tests were not added as they were set to be implemented in a different issue. It was noted that a full removal was not guaranteed in the documentation. 

## Related Issue
Fixes #154

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / CI / Docs
- [ ] Other

## How to Test
```
bash scripts/validate_strict.sh
```

## Checklist
- [x] Code follows project style (`cargo fmt` + `cargo clippy`)
- [ ] Tests added/updated and passing (`cargo test`)
- [x] Documentation updated (if applicable)
