### PR TITLE
refactor(core): document schema and simplify cleanup internals

### DIFF
--- a/docs/execution-plans/2026-04-09-issue-safe-cleanup-pass.md
+++ b/docs/execution-plans/2026-04-09-issue-safe-cleanup-pass.md
@@ -1,0 +1,61 @@
+# Goal
+
+Perform a conservative repository cleanup pass that improves readability,
+maintainability, and internal documentation without materially advancing any
+open issue.
+
+# Scope / Non-goals
+
+In scope:
+- Internal readability refactors in existing data/model code
+- Beginner-friendly rustdoc and comment cleanup for existing public types
+- Recording issue boundaries and verification evidence for this pass
+
+Out of scope:
+- Removal flow behavior or tests (`#20`, `#195`)
+- New MVP test-lane work (`#16`)
+- User-facing documentation overhauls (`#15`, `#89`, `#168`, `#169`, `#170`, `#171`)
+- Release/CI/install work (`#14`, `#18`, `#88`, `#172`, `#173`, `#230`)
+- Signature feed, `scan-url`, or deep-scan expansion (`#12`, `#17`, `#108`, `#157`-`#163`)
+- `Cargo.toml` metadata work (`#132`) or script hardening (`#134`)
+
+# Inputs And Linked Artifacts
+
+- Milestone 2 issues confirmed open on 2026-04-09 via GitHub API:
+  - `#16` `[TRACKING][MVP] Step 20/23 (Phase 6): Testing — MVP test lane`
+  - `#20` `[TRACKING][MVP] Step 12/23 (Phase 2): Removal — MVP delete flows`
+  - `#195` `MVP: add remove-file CLI tests for --force, missing file, and directory rejection`
+- Broader open-issue inventory reviewed by title/label before editing
+- `docs/Comprehensive_Plan_2026.txt`
+- `docs/contributing-guidelines.md`
+- `docs/development-guide.md`
+- `tests/README.md`
+- `docs/architecture-documentation.md`
+
+# Acceptance Criteria Checklist
+
+- [x] Every non-trivial change was checked against open-issue overlap first
+- [x] Changes stay within existing implementation boundaries
+- [x] No user-facing CLI flows owned by open issues were altered
+- [x] Validation evidence is captured with the repository baseline command
+
+# Implementation Steps
+
+1. Confirm the open milestone issues and broader open-issue map.
+2. Run baseline validation before edits.
+3. Limit edits to issue-safe cleanup areas.
+4. Re-run validation and inspect the final diff against the issue map.
+
+# Verification Matrix
+
+| Criterion | Evidence | Status |
+| --- | --- | --- |
+| Issue overlap checked before editing | GitHub issue queries for milestone 2 and all open issue titles | Pass |
+| Repository baseline is green before/after cleanup | `./scripts/validate_strict.sh` | Pass |
+| CLI/test-lane issue work remained untouched | Diff review limited to internal data/model docs/refactors plus this execution plan | Pass |
+
+# Risks And Rollback Notes
+
+- Risk: internal cleanup could accidentally drift into issue-owned behavior.
+  Mitigation: avoid removal, CLI contract, updater workflow, docs, release, and new test work.
+- Rollback: revert only the focused documentation/refactor changes from this pass if any regression appears.

--- a/src/database/operations.rs
+++ b/src/database/operations.rs
@@ -8,11 +8,16 @@ use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use super::schema::{
-    MalwareSignature, SignatureDatabase, create_seed_database, parse_hash_type, signature_key,
+    MalwareSignature, SIGNATURE_DATABASE_SCHEMA_VERSION, SignatureDatabase, create_seed_database,
+    parse_hash_type, signature_key,
 };
 use crate::utils::HashType;
 
-/// Manages the local malware signature database.
+/// Lazy-loading manager for the local signature database file.
+///
+/// The manager caches the most recent in-memory snapshot and persists writes
+/// through a write-then-rename flow so readers never observe partially written
+/// JSON.
 pub struct DatabaseManager {
     db_path: PathBuf,
     database: Option<SignatureDatabase>,
@@ -220,36 +225,9 @@ impl DatabaseManager {
             database.metadata.hash_types.iter().copied().collect();
 
         for (key, mut signature) in old_signatures {
-            let canonical_key = if let Some((prefix, hash_part)) = key.split_once(':') {
-                if let Some(parsed_type) = parse_hash_type(prefix) {
-                    if signature.hash_type != parsed_type {
-                        signature.hash_type = parsed_type;
-                        migrated = true;
-                    }
-                    if !signature.hash.eq_ignore_ascii_case(hash_part) {
-                        signature.hash = hash_part.to_ascii_lowercase();
-                        migrated = true;
-                    }
-                    signature_key(parsed_type, &signature.hash)
-                } else {
-                    let hash_type = signature.hash_type;
-                    if signature.hash.is_empty() {
-                        // Older data sometimes stored the raw hash as the map
-                        // key and left the struct field empty.
-                        signature.hash = key.clone();
-                    }
-                    migrated = true;
-                    signature_key(hash_type, &signature.hash)
-                }
-            } else {
-                if signature.hash.is_empty() {
-                    // Legacy databases without prefixes are treated as "best
-                    // known hash_type + raw hash" and rewritten on save.
-                    signature.hash = key.clone();
-                }
-                migrated = true;
-                signature_key(signature.hash_type, &signature.hash)
-            };
+            let (canonical_key, entry_migrated) =
+                Self::normalize_signature_entry(&key, &mut signature);
+            migrated |= entry_migrated;
 
             hash_types.insert(signature.hash_type);
             normalized.insert(canonical_key, signature);
@@ -261,7 +239,7 @@ impl DatabaseManager {
         }
 
         database.signatures = normalized;
-        database.metadata.schema_version = 2;
+        database.metadata.schema_version = SIGNATURE_DATABASE_SCHEMA_VERSION;
         database.metadata.signature_count = database.signatures.len();
         if hash_types.is_empty() {
             hash_types.insert(HashType::Sha256);
@@ -271,8 +249,42 @@ impl DatabaseManager {
         (database, migrated)
     }
 
+    fn normalize_signature_entry(key: &str, signature: &mut MalwareSignature) -> (String, bool) {
+        if let Some((prefix, hash_part)) = key.split_once(':') {
+            return match parse_hash_type(prefix) {
+                Some(parsed_type) => {
+                    let mut migrated = false;
+                    if signature.hash_type != parsed_type {
+                        signature.hash_type = parsed_type;
+                        migrated = true;
+                    }
+                    if !signature.hash.eq_ignore_ascii_case(hash_part) {
+                        signature.hash = hash_part.to_ascii_lowercase();
+                        migrated = true;
+                    }
+                    (signature_key(parsed_type, &signature.hash), migrated)
+                }
+                None => {
+                    if signature.hash.is_empty() {
+                        // Older data sometimes stored the raw hash as the map
+                        // key and left the struct field empty.
+                        signature.hash = key.to_string();
+                    }
+                    (signature_key(signature.hash_type, &signature.hash), true)
+                }
+            };
+        }
+
+        if signature.hash.is_empty() {
+            // Legacy databases without prefixes are treated as "best known
+            // hash_type + raw hash" and rewritten on save.
+            signature.hash = key.to_string();
+        }
+        (signature_key(signature.hash_type, &signature.hash), true)
+    }
+
     fn refresh_metadata(database: &mut SignatureDatabase) {
-        database.metadata.schema_version = 2;
+        database.metadata.schema_version = SIGNATURE_DATABASE_SCHEMA_VERSION;
         database.metadata.signature_count = database.signatures.len();
         database.metadata.last_updated = Utc::now();
 
@@ -299,6 +311,8 @@ impl DatabaseManager {
     }
 
     fn hash_types_in_order(set: &HashSet<HashType>) -> Vec<HashType> {
+        // Keep metadata ordering stable so diff reviews stay readable and tests
+        // do not depend on hash-set iteration order.
         let mut out = Vec::new();
         if set.contains(&HashType::Sha256) {
             out.push(HashType::Sha256);

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -4,9 +4,17 @@ use std::collections::HashMap;
 
 use crate::utils::HashType;
 
-/// Main database structure containing all malware signatures.
+/// Current on-disk schema version for `signatures.json`.
+pub const SIGNATURE_DATABASE_SCHEMA_VERSION: u32 = 2;
+const DEFAULT_DATABASE_VERSION: &str = "1.0.0";
+const DEFAULT_DATABASE_SOURCE: &str = "local";
+const DEFAULT_DATABASE_UPDATE_URL: &str =
+    "https://github.com/Jordan231111/MalwareMinimizer/releases/latest/download/signatures.json";
+
+/// Persisted signature database with metadata plus a canonical lookup table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SignatureDatabase {
+    /// Versioning and provenance metadata for the current database snapshot.
     pub metadata: DatabaseMetadata,
     /// Canonical `hash_type:hash` lookup map used by the scanner for O(1)
     /// signature checks.
@@ -17,24 +25,34 @@ pub struct SignatureDatabase {
 /// Metadata about the signature database.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatabaseMetadata {
+    /// On-disk schema version for compatibility and migrations.
     #[serde(default = "default_schema_version")]
     pub schema_version: u32,
+    /// Human-readable release/version for the current database contents.
     #[serde(default = "default_database_version")]
     pub version: String,
+    /// Count of signature entries currently present in `signatures`.
     #[serde(default)]
     pub signature_count: usize,
+    /// Timestamp for when this database snapshot was last written.
     #[serde(default = "now_utc")]
     pub last_updated: DateTime<Utc>,
+    /// High-level source label such as `local`, `seed`, or a feed name.
     #[serde(default = "default_source")]
     pub source: String,
+    /// Preferred URL for fetching future database updates.
     #[serde(default = "default_update_url")]
     pub update_url: String,
+    /// Optional HTTP ETag from the last successful manifest/database fetch.
     #[serde(default)]
     pub etag: Option<String>,
+    /// Minimum application version required by the fetched database, if any.
     #[serde(default)]
     pub min_app_version: Option<String>,
+    /// Hash algorithms represented by the currently stored signatures.
     #[serde(default = "default_hash_types")]
     pub hash_types: Vec<HashType>,
+    /// Reserved signing-key identifier for future signature verification work.
     #[serde(default)]
     pub signing_key_id: Option<String>,
 }
@@ -42,28 +60,43 @@ pub struct DatabaseMetadata {
 /// A single malware signature entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MalwareSignature {
+    /// Stable identifier for the signature entry itself.
     pub id: String,
+    /// Human-readable threat name shown in CLI output.
     pub name: String,
+    /// Digest or other signature value used for matching.
     pub hash: String,
+    /// Algorithm that produced `hash`.
     #[serde(default)]
     pub hash_type: HashType,
+    /// Whether the entry matches files, URLs, or another modality.
     #[serde(default)]
     pub signature_type: SignatureType,
+    /// Reserved partial hashes for future heuristic/partial-match flows.
     #[serde(default)]
     pub partial_hashes: Option<Vec<String>>,
+    /// User-facing severity level for the detected threat.
     pub severity: MalwareSeverity,
+    /// Short explanation of what the signature represents.
     pub description: String,
+    /// When this signature was first added to the database.
     pub added_date: DateTime<Utc>,
+    /// Platforms for which the signature is relevant.
     #[serde(default)]
     pub platforms: Vec<Platform>,
+    /// Lightweight categorization tags used for grouping/searching later.
     #[serde(default)]
     pub tags: Vec<String>,
+    /// Optional URL associated with a URL-based signature entry.
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional pattern payload for non-hash matching modes.
     #[serde(default)]
     pub pattern: Option<String>,
+    /// Feed/source name that supplied this signature.
     #[serde(default)]
     pub source: Option<String>,
+    /// Upstream source identifier, if the provider exposes one.
     #[serde(default)]
     pub source_id: Option<String>,
 }
@@ -119,20 +152,19 @@ impl Default for SignatureDatabase {
 }
 
 fn default_schema_version() -> u32 {
-    2
+    SIGNATURE_DATABASE_SCHEMA_VERSION
 }
 
 fn default_database_version() -> String {
-    "1.0.0".to_string()
+    DEFAULT_DATABASE_VERSION.to_string()
 }
 
 fn default_source() -> String {
-    "local".to_string()
+    DEFAULT_DATABASE_SOURCE.to_string()
 }
 
 fn default_update_url() -> String {
-    "https://github.com/Jordan231111/MalwareMinimizer/releases/latest/download/signatures.json"
-        .to_string()
+    DEFAULT_DATABASE_UPDATE_URL.to_string()
 }
 
 fn default_hash_types() -> Vec<HashType> {
@@ -158,7 +190,10 @@ pub fn parse_hash_type(prefix: &str) -> Option<HashType> {
     }
 }
 
-/// Create an initial seed database with test signatures including EICAR.
+/// Create the built-in seed database with safe deterministic fixtures.
+///
+/// The bundled EICAR signature keeps the repository usable for local scanning
+/// and tests without introducing real malware samples.
 pub fn create_seed_database() -> SignatureDatabase {
     let mut db = SignatureDatabase::default();
 

--- a/src/scanner/engine.rs
+++ b/src/scanner/engine.rs
@@ -125,26 +125,32 @@ impl ScanResult {
         self.elapsed_ms = elapsed_ms;
     }
 
+    /// Return the elapsed scan time in milliseconds.
     pub fn elapsed_ms(&self) -> u128 {
         self.elapsed_ms
     }
 
+    /// Return the number of file candidates discovered before scanning began.
     pub fn discovered_file_count(&self) -> u64 {
         self.discovered_files
     }
 
+    /// Return the number of file candidates that were processed.
     pub fn scanned_file_count(&self) -> u64 {
         self.scanned_files
     }
 
+    /// Return the number of files that failed to scan cleanly.
     pub fn failed_scan_count(&self) -> u64 {
         self.failed_scans
     }
 
+    /// Return the number of malicious files detected during the scan.
     pub fn malicious_file_count(&self) -> u64 {
         self.malicious_files
     }
 
+    /// Borrow the per-file detections collected during the scan.
     pub fn detections(&self) -> &[FileResult] {
         &self.detections
     }
@@ -192,14 +198,17 @@ impl FileResult {
         self.malicious
     }
 
+    /// Return the detected threat name, if the file matched a signature.
     pub fn threat_name(&self) -> Option<&str> {
         self.threat_name.as_deref()
     }
 
+    /// Return the computed file hash, if hashing completed successfully.
     pub fn file_hash(&self) -> Option<&str> {
         self.file_hash.as_deref()
     }
 
+    /// Return the scanned file path, if the result came from a concrete file.
     pub fn file_path(&self) -> Option<&Path> {
         self.file_path.as_deref()
     }

--- a/src/scanner/fast_scan.rs
+++ b/src/scanner/fast_scan.rs
@@ -7,14 +7,17 @@ use anyhow::Result;
 use super::engine::{ScanEngine, ScanOptions};
 use super::{FileResult, ScanResult};
 
+/// Runtime configuration for the existing fast scan implementation.
 #[derive(Clone, Debug, Default)]
 pub struct ScannerConfig {
     database_path: Option<PathBuf>,
 }
 
 impl ScannerConfig {
-    /// Store an owned database path override. The scanner config owns this
-    /// value because the engine may outlive the caller-provided argument.
+    /// Store an owned database path override.
+    ///
+    /// The config owns this value because the scanner may outlive the original
+    /// caller-provided argument.
     pub fn with_database_path(mut self, path: PathBuf) -> Self {
         self.database_path = Some(path);
         self
@@ -26,6 +29,7 @@ impl ScannerConfig {
     }
 }
 
+/// Thin public wrapper around the shared hash-based scan engine.
 pub struct FastScan {
     engine: ScanEngine,
     // Keep the original config available for future scan-lane expansion even
@@ -47,6 +51,8 @@ impl FastScan {
         })
     }
 
+    /// Scan every supported file beneath `path` and return an aggregated
+    /// summary.
     pub fn scan_directory(&mut self, path: &Path) -> Result<ScanResult> {
         self.engine.scan_directory(path)
     }
@@ -62,6 +68,7 @@ impl FastScan {
         self.engine.scan_directory_with_bar(path, update_progress)
     }
 
+    /// Scan a single file and return its per-file result.
     pub fn scan_file(&mut self, path: &Path) -> Result<FileResult> {
         self.engine.scan_file(path)
     }


### PR DESCRIPTION
## Description
This PR performs a conservative issue-safe cleanup pass focused on internal maintainability and documentation.

Changes included:
- centralize signature database schema/default constants
- add beginner-friendly rustdoc for persisted database and scanner result types
- simplify legacy signature-key normalization in the database manager
- record the cleanup scope, non-goals, and validation evidence in an execution plan

This PR intentionally avoids active open-issue work. It does not change removal flows, CLI contracts, updater workflows, user-facing docs, release automation, signature-feed work, or deep-scan behavior.

## Related Issue
N/A. This PR intentionally does not fix or close an open issue.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / CI / Docs
- [ ] Other

## How to Test
1. Run `./scripts/validate_strict.sh`
2. Inspect the touched files for documentation/readability-only scope:
   - `src/database/schema.rs`
   - `src/database/operations.rs`
   - `src/scanner/fast_scan.rs`
   - `src/scanner/engine.rs`
   - `docs/execution-plans/2026-04-09-issue-safe-cleanup-pass.md`
3. Confirm no removal/test-lane/user-doc/release/signature/deep-scan workflows changed.

## Checklist
- [x] Code follows project style (`cargo fmt` + `cargo clippy`)
- [x] Tests added/updated and passing (`cargo test`)
- [x] Documentation updated (if applicable)
