### PR TITLE
Database research

### DIFF
--- a/docs/database-matrix.md
+++ b/docs/database-matrix.md
@@ -1,0 +1,9 @@
+# Potential Database Sources
+| Source             | Type | License  | Redistribution | API Key | Rate Limits  | Update Cadence | Integration Methods                                             |
+|--------------------|------|----------|----------------|---------|--------------|----------------|-----------------------------------------------------------------|
+| ClamAv             | Hash |  GPL 2.0 | Yes            | No      | None         | Can't Update   | Download from Github then export Hash Info then Convert to JSON |
+| MalwareBazaar      | Hash | Fair Use | Yes            | Yes     | 2000         | Hourly         | Download from Website (Can only be updated via API Calls)       |
+| MantaRay Forensics | Hash | Unknown  | Probably       | No      | None         | None           | Download from Source Forge and convert to JSON                  |
+| EICAR              | Hash | N/A      | Yes            | No      | None         | N/A            | Direct Addition                                                 |
+| Phishtank          | URL  | Unknown  | Yes            | Yes     | Yes, Unknown | Hourly         | Download Database then use api calls to update                  |
+| OpenPhish          | URL  |          | Yes            | Yes     | Not Stated   | 15 Minutes     | SQL database available via subscription                         |


### PR DESCRIPTION
## Description
These are my findings after going through the potential sources listed in #160. Most existing hash databases are either not shared or locked behind paywalls. We can get the initial ClamAV database but I don't see it as being a viable continuous update stream. Malware Bazaar Is very good though it will require the user to input an api key in order to get regular updates . MantaRay Forensics seemed like another good source database but I was unfamiliar with the database formats so there could be some challenge in extracting the information we care about. In regards to URL sources the only good one is PhishTank which provides a full database download as well as a method to update via api. I would advise against trying to integrate Open Phish as access to its full database offline seems to be restricted to a subscription. Overall most sources seem unwilling to provide their full database for download.  

## Related Issue
Fixes #160

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / CI / Docs
- [x] Other

## How to Test
N/A

## Checklist
- [ ] Code follows project style (`cargo fmt` + `cargo clippy`)
- [ ] Tests added/updated and passing (`cargo test`)
- [x] Documentation updated (if applicable)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jordan231111/malwareminimizer/pull/263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
